### PR TITLE
pass an array for a group of pid files.

### DIFF
--- a/api.js
+++ b/api.js
@@ -164,25 +164,31 @@ var commands = {
     service.status = "unknown";
     service.statusCode = 0;
     service.message = '';
-    try {
-      var pid = fs.readFileSync(serviceDefinition.pidfile);
-    } catch (e) {
-      service.status = "unknown";
-      service.statusCode = e.errno;
-      service.message = e.message;
-      return;
+    var pidfiles = [serviceDefinition.pidfile];
+    
+    if(serviceDefinition.pidfile.constructor === Array){
+      pidfiles = serviceDefinition.pidfile;
     }
-    try {
-      process.kill(pid, 0);
-      service.status = "up";
-      service.statusCode = 0;
-      service.message = '';
-    } catch (e) {
-      service.status = "down";
-      service.statusCode = e.errno;
-      service.message = e.message;
-      return;
+    for(var index =0; index< pidfiles.length; index ++){
+      try {
+        var pid = fs.readFileSync(pidfiles[index]);
+      } catch (e) {
+        service.status = "unknown";
+        service.statusCode = e.errno;
+        service.message = e.message;
+        return;
+      }
+      try {
+        process.kill(pid, 0);
+      } catch (e) {
+        service.status = "down";
+        service.statusCode = e.errno;
+        service.message = e.message;
+        return;
+      }
+      
     }
+    service.status = "up";
   }
 };
 

--- a/settings.js
+++ b/settings.js
@@ -13,7 +13,7 @@ exports.create = function() {
     serviceDelay: 500
   };
 
-  settings['olivier'] = {
+  settings['localhost'] = {
     port: 8080,
     services: [{
       name: 'couchdb', 
@@ -23,20 +23,6 @@ exports.create = function() {
       port: '5984',
       path: '/'
     }, {
-      name: 'bazoud.free.fr', 
-      label: 'Olivier Bazoud blog',
-      check: 'http',
-      host: 'bazoud.free.fr', 
-      port: '80',
-      path: '/'
-    }, {
-      name: 'bazoud.free.fr php',
-      label: 'Olivier Bazoud blog test.php',
-      check: 'http',
-      host: 'bazoud.free.fr',
-      port: '80',
-      path: '/test.php'
-    }, {
       name: 'redis', 
       label: 'Redis server @ local',
       check: 'tcp',
@@ -44,18 +30,10 @@ exports.create = function() {
       port: '6379',
       cmd: 'PING\r\n'
     }, {
-      name: 'FTP Local',
-      label: 'Ftp @ local',
-      check: 'ftp',
-      host: 'localhost',
-      port: '21',
-      username: 'statusdashboard',
-      password: 'statusdashboard'
-    }, {
       name: 'PID file',
       label: 'Pid @ local',
       check: 'pidfile',
-      pidfile: '/tmp/terminal.pid'
+      pidfile: ['/Users/sreeix/code/talkto/mphoria/tmp/pids/resque_worker_1.pid','/Users/sreeix/code/talkto/mphoria/tmp/pids/resque_worker_2.pid']
     }],
     serviceInterval: 5000,
   };

--- a/settings.js
+++ b/settings.js
@@ -13,7 +13,7 @@ exports.create = function() {
     serviceDelay: 500
   };
 
-  settings['localhost'] = {
+  settings['olivier'] = {
     port: 8080,
     services: [{
       name: 'couchdb', 
@@ -23,6 +23,20 @@ exports.create = function() {
       port: '5984',
       path: '/'
     }, {
+      name: 'bazoud.free.fr', 
+      label: 'Olivier Bazoud blog',
+      check: 'http',
+      host: 'bazoud.free.fr', 
+      port: '80',
+      path: '/'
+    }, {
+      name: 'bazoud.free.fr php',
+      label: 'Olivier Bazoud blog test.php',
+      check: 'http',
+      host: 'bazoud.free.fr',
+      port: '80',
+      path: '/test.php'
+    }, {
       name: 'redis', 
       label: 'Redis server @ local',
       check: 'tcp',
@@ -30,10 +44,18 @@ exports.create = function() {
       port: '6379',
       cmd: 'PING\r\n'
     }, {
+      name: 'FTP Local',
+      label: 'Ftp @ local',
+      check: 'ftp',
+      host: 'localhost',
+      port: '21',
+      username: 'statusdashboard',
+      password: 'statusdashboard'
+    }, {
       name: 'PID file',
       label: 'Pid @ local',
       check: 'pidfile',
-      pidfile: ['/Users/sreeix/code/talkto/mphoria/tmp/pids/resque_worker_1.pid','/Users/sreeix/code/talkto/mphoria/tmp/pids/resque_worker_2.pid']
+      pidfile: '/tmp/terminal.pid'
     }],
     serviceInterval: 5000,
   };


### PR DESCRIPTION
We use a group of processes(like a set of resque workers). This patch lets users specify an array of pidfiles to be checked. This allows us to group all similar processes into one line item instead of adding a row for each.

Let me know what you think.
