### PR TITLE
Loads plugins and notiifies them on status for each service.

### DIFF
--- a/api.js
+++ b/api.js
@@ -78,7 +78,7 @@ var commands = {
       service.status = "down";
       service.statusCode = 0;
       service.message = e.message;
-      controller.emit("down", service);
+      controller.emit(service.status, service);
     });
   },
   https : function(serviceDefinition, service) {
@@ -119,14 +119,13 @@ var commands = {
         service.status = "up";
         service.statusCode = 0;
         service.message = "";
-        controller.emit(up, service);
       } else {
         service.status = "critical";
         service.statusCode = 0;
         service.message = "Expected " + serviceDefinition.rcv + " but was " + buffer;
-        controller.emit('critical', service);
       }
       stream.end();
+      controller.emit(service.status, service);
     });
     stream.addListener('connect', function () {
       stream.write(serviceDefinition.cmd);
@@ -138,7 +137,7 @@ var commands = {
       service.status = "down";
       service.statusCode = e.errno;
       service.message = e.message;
-      controller.emit("down", service);      
+      controller.emit(service.status, service);      
     });
   },
   ftp : function(serviceDefinition, service) {
@@ -168,7 +167,7 @@ var commands = {
           service.status = "up";
           service.statusCode = 0;
           service.message = "";
-          controller.emit('up', service);
+          controller.emit(service.status, service);
         });
       });
     });
@@ -177,14 +176,14 @@ var commands = {
       service.status = "down";
       service.statusCode = status;
       service.message = message;
-      controller.emit('down', service);
+      controller.emit(service.status, service);
     };
 
     stream.addListener('error', function (e) {
       service.status = "down";
       service.statusCode = 0;
       service.message = e.message;
-      controller.emit('error', service);
+      controller.emit(service.status, service);
     });
 
   },
@@ -204,7 +203,7 @@ var commands = {
         service.status = "unknown";
         service.statusCode = e.errno;
         service.message = e.message;
-        controller.emit('unknown', service);
+        controller.emit(service.status, service);
         return;
       }
       try {
@@ -220,13 +219,12 @@ var commands = {
         service.status = "down";
         service.statusCode = e.errno;
         service.message = e.message;
-        controller.emit("down", service);
+        controller.emit(service.status, service);
         return;
       }
     }
     service.status = "up";
-    controller.emit("up", service);
-    
+    controller.emit(service.status, service);
   }
 };
 

--- a/plugins/test_plugin.js
+++ b/plugins/test_plugin.js
@@ -1,0 +1,21 @@
+// Needs to export a create method that takes a handle to the controller.
+// up/down/unknown/critical are expected messages. Probably need to add transition status up -> down, down->up or up->critical
+
+exports.create = function(api){
+  console.log('Creating the plugin');
+  api.on('up', function(service){
+    console.log('success...'+ service.name);
+  });  
+
+  api.on('down', function(service){
+    console.log('failed...'+ service.name);
+  });  
+
+  api.on('unknown', function(service){
+    console.log('unknown...'+ service.name);
+  });  
+
+  api.on('critical', function(service){
+    console.log('critical...'+ service.name);
+  });  
+};


### PR DESCRIPTION
Here is a small patch that loads and sends notifications to the plugins. 
Plugins are loaded from api.js. and are stored in the plugins folder.
the notifications currently support up/down/unknown/critical (status update every refresh)

We could also just hook to refresh to get one big status update.
This would pave the way for interesting usages. twitter notification is one i am thinking about now.

Thoughts?
