### PR TITLE
Adding a status dashboard protocol

### DIFF
--- a/api.js
+++ b/api.js
@@ -10,7 +10,7 @@ var EventEmitter = require('events').EventEmitter;
 var controller = new EventEmitter();
 module.exports = controller;
 
-var plugins =[];
+var plugins = [];
 fs.readdir('./plugins', function(err, files){
   if(!err){
    plugins = _.map(files, function(file){
@@ -69,6 +69,20 @@ var checkRange = function(min, max, value) {
     return true;
   }
   return false;
+};
+var checkStatusDashboardResponse = function(response, serviceDefinition, service) {
+  if(response.statusCode === 200){
+    response.on('data', function(chunk){
+      summary = JSON.parse(chunk);
+      if(summary.critical === 0 && summary.down === 0 && summary.unknown ===0){
+        service.status = 'up';
+      }else {
+        service.status = 'down';
+        service.message = "Services up: "+ summary.up + ", Services down: "+ summary.down + ", Services critical: "+summary.critical + ", Services unknown: "+summary.unknown 
+      }
+      controller.emit(service.status, service);
+    });
+  }
 };
 
 var checkHttpValueResponse = function(response, serviceDefinition, service) {
@@ -264,6 +278,24 @@ var commands = {
     }
     service.status = "up";
     controller.emit(service.status, service);
+  },
+  statusdashboard : function(serviceDefinition, service) {
+    var options = {
+      host: serviceDefinition.host,
+      port: serviceDefinition.port,
+      path: '/api/summarize'
+    };
+    http.get(options, function(response) {
+      service.message = '';
+      checkHttpStatusCode(response, service);
+      checkStatusDashboardResponse(response, serviceDefinition, service);
+    })
+    .on('error', function(e) {
+      service.status = "down";
+      service.statusCode = 0;
+      service.message = e.message;
+      controller.emit(service.status, service);
+    });
   }
 };
 

--- a/api.js
+++ b/api.js
@@ -78,7 +78,7 @@ var checkStatusDashboardResponse = function(response, serviceDefinition, service
         service.status = 'up';
       }else {
         service.status = 'down';
-        service.message = "Services up: "+ summary.up + ", Services down: "+ summary.down + ", Services critical: "+summary.critical + ", Services unknown: "+summary.unknown 
+        service.message = "Services up: "+ summary.up + ", Services down: "+ summary.down + ", Services critical: "+summary.critical + ", Services unknown: "+summary.unknown; 
       }
       controller.emit(service.status, service);
     });


### PR DESCRIPTION
In this commit i have added a status dashboard protocol, so that i can chain multiple dashboards into another compisite dashboard. This is a decent way for hooking up multiple statusdashboards togather(Unless you intend to add multiple environments into the same dashboard)

My usecase is this.

We have a production environment as well as an preproduction environment. We'd like to have a single dashboard for both. Currently it just shows the summary.
I wonder if we can enhance to expand and collapse the internal statuss

The current implementation shows the following message if there are errors.

http://twitpic.com/5k7img
