### PR TITLE
Redis status storage

### DIFF
--- a/api.js
+++ b/api.js
@@ -2,7 +2,6 @@ var http = require('http');
 var https = require('https');
 var net = require('net');
 var sys = require('sys');
-var fs = require('fs');
 var logger = require('util');
 var _ = require('underscore')._;
 var settings = require('./settings').create();
@@ -10,13 +9,10 @@ var EventEmitter = require('events').EventEmitter;
 var controller = new EventEmitter();
 module.exports = controller;
 
-var plugins =[];
-fs.readdir('./plugins', function(err, files){
-  if(!err){
-   plugins = _.map(files, function(file){
-     return require('./plugins/'+file).create(controller);
-   });
- }
+
+var plugins = _.map(settings.plugins, function(plugin){
+  console.log("creating plugin "+ plugin.name);
+  return require('./plugins/'+plugin.name).create(controller, plugin.options);
 });
   
 var status = {};

--- a/plugins/redis_storage.js
+++ b/plugins/redis_storage.js
@@ -34,4 +34,11 @@ exports.create = function(api, options){
     storeStatus(service);
     console.log('critical...'+ service.name);
   });  
+  
+  return {
+    history: function(service, callback){
+      console.log("getting history");
+      client.lrange('statusdashboard:'+service.name, 0, 100,callback);
+    }
+  };
 };

--- a/plugins/redis_storage.js
+++ b/plugins/redis_storage.js
@@ -1,0 +1,32 @@
+// Needs to export a create method that takes a handle to the controller.
+// up/down/unknown/critical are expected messages. Probably need to add transition status up -> down, down->up or up->critical
+// Needs redis to be running.
+// needs noderedis. install it via npm install hiredis redis
+var redis = require("redis"),client = redis.createClient();
+
+var storeStatus = function (service){
+  client.rpush("statusdashboard:"+service.name, JSON.stringify({time: new Date().valueOf(), status: service.status, message: service.message, code:service.statusCode}));
+  
+}    
+exports.create = function(api){
+  console.log('Creating the Redis storage plugin');
+  api.on('up', function(service){
+    storeStatus(service);
+    console.log('success...'+ service.name);
+  });  
+
+  api.on('down', function(service){
+    storeStatus(service);
+    console.log('down...'+ service.name);
+  });  
+
+  api.on('unknown', function(service){
+    storeStatus(service);
+    console.log('unknown...'+ service.name);
+  });  
+
+  api.on('critical', function(service){
+    storeStatus(service);
+    console.log('critical...'+ service.name);
+  });  
+};

--- a/plugins/redis_storage.js
+++ b/plugins/redis_storage.js
@@ -2,14 +2,19 @@
 // up/down/unknown/critical are expected messages. Probably need to add transition status up -> down, down->up or up->critical
 // Needs redis to be running.
 // needs noderedis. install it via npm install hiredis redis
-var redis = require("redis"),client = redis.createClient();
+var redis = require("redis")
 
-var storeStatus = function (service){
-  client.rpush("statusdashboard:"+service.name, JSON.stringify({time: new Date().valueOf(), status: service.status, message: service.message, code:service.statusCode}));
-  
-}    
-exports.create = function(api){
+exports.create = function(api, options){
   console.log('Creating the Redis storage plugin');
+  var client = redis.createClient(options.port, options.host);
+  client.on('error', function(err){
+     console.log("Error " + err);
+  });
+  
+  var storeStatus = function (service){
+    client.rpush("statusdashboard:"+service.name, JSON.stringify({time: new Date().valueOf(), status: service.status, message: service.message, code:service.statusCode}));
+  }
+      
   api.on('up', function(service){
     storeStatus(service);
     console.log('success...'+ service.name);

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ var api = require('./api');
 // router
 router.get(/^\/api\/services$/).bind(api.services);
 router.get(/^\/api\/services\/([a-z\-]+)$/).bind(api.servicesElement);
+router.get(/^\/api\/services\/history\/([a-z\-]+)$/).bind(api.serviceHistory);
 router.get(/^\/api\/summarize$/).bind(api.summarize);
 
 // static

--- a/settings.js
+++ b/settings.js
@@ -10,7 +10,8 @@ exports.create = function() {
     port: 8080,
     services: [],
     serviceInterval: 20000,
-    serviceDelay: 500
+    serviceDelay: 500,
+    plugins: [{name: 'redis_storage', description: 'stores status data into redis.', options: {host: '127.0.0.1', port:6379}}]
   };
 
   settings['olivier'] = {


### PR DESCRIPTION
Adding support for storing the history of status updates into redis. This we can track downtimes. I was thinking of adding a sparkline or uptime/downtime stats on the dashboard as well.

I had to change the way we load plugins 
1) There can be any number of files in the plugins folder. Only plugins that are specified name should match the file name  in plugins folder for it to be created
2) Options are passed for the plugin so that it can be created with spefic params
(I have added an example of redis_storage configuration in the settings.js. Let me know if i should keep it pristine)

Also added a http://<dashboard_url>/api/services/history/<service> api so that we can track history of the service.
