### PR TITLE
Changes to make status dashboard to work with node 0.6.3

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,7 +1,6 @@
 var http = require('http');
 var https = require('https');
 var net = require('net');
-var sys = require('sys');
 var fs = require('fs');
 var logger = require('util');
 var _ = require('underscore')._;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
         "underscore": "1.1.6",
         "irc": "0.2.0",
         "twitter": "0.1.17",
-        "redis": "0.6.6",
+        "redis": "0.7.1",
+        "hiredis": "0.1.13",
         "nodemailer": "0.1.22"
     },
     "engine": "node 0.4.8"

--- a/plugins/history/history_plugin.js
+++ b/plugins/history/history_plugin.js
@@ -1,5 +1,4 @@
 var logger = require('util');
-var sys = require('sys');
 var client;
 var mysettings;
 

--- a/plugins/mail/mail_plugin.js
+++ b/plugins/mail/mail_plugin.js
@@ -1,5 +1,4 @@
 var logger = require('util');
-var sys = require('sys');
 
 exports.create = function(api, settings) {
   if (settings.plugins && settings.plugins.mail && settings.plugins.mail.enable) {

--- a/plugins/twitter/twitter_plugin.js
+++ b/plugins/twitter/twitter_plugin.js
@@ -1,5 +1,4 @@
-var logger = require('util');
-var sys = require('sys');
+var util = require('util');
 
 exports.create = function(api, settings) {
   if (settings.plugins && settings.plugins.twitter && settings.plugins.twitter.enable) {
@@ -15,10 +14,10 @@ exports.create = function(api, settings) {
 
     twit.tweet = function(message, options) {
       twit.verifyCredentials(function (data) {
-        // logger.log("verifyCredentials: " + sys.puts(sys.inspect(data)));
+        // util.log("verifyCredentials: " + util.puts(util.inspect(data)));
       }).updateStatus(message, function (data) {
-        logger.log("Send a tweet: " + message);
-        // logger.log("updateStatus: " + sys.puts(sys.inspect(data)));
+        util.log("Send a tweet: " + message);
+        // util.log("updateStatus: " + util.puts(util.inspect(data)));
       });
     };
 

--- a/server.js
+++ b/server.js
@@ -1,5 +1,4 @@
-var logger = require('util');
-var sys = require('sys');
+var util = require('util');
 var http = require('http');
 var journey = require('journey');
 var router = new(journey.Router)();
@@ -8,11 +7,11 @@ var url = require('url');
 var _ = require('underscore')._;
 
 process.on('exit', function () {
-  logger.log('Bye bye Statusdashboard.');
+  util.log('Bye bye Statusdashboard.');
 });
 
 process.on('uncaughtException', function(err) {
-  logger.log(err);
+  util.log(err);
 });
 
 String.prototype.startsWith = function(str) {
@@ -77,14 +76,14 @@ io.set('log level', 1);
 
 io.sockets.on('connection', function(socket) {
   count++;
-  logger.log('New client connected! (' + count + ')');
+  util.log('New client connected! (' + count + ')');
   socket.emit('title', settings.title);
   socket.emit('status', api.getStatus());
   socket.broadcast.emit('count', count);
 
   socket.on('disconnect', function() {
     count--;
-    logger.log('Client disconnect! (' + count + ')');
+    util.log('Client disconnect! (' + count + ')');
     socket.broadcast.emit('count', count);
   });
   api.on("refresh", function(status) {
@@ -97,12 +96,12 @@ api.on("routeContribution", function(route) {
 });
 
 api.on("staticContribution", function(plugin) {
-  logger.log("Add static contribution: " + plugin);
+  util.log("Add static contribution: " + plugin);
   var docRoot = __dirname + '/plugins/' + plugin + '/public';
   pluginsDocRoot.push( { prefix: "/api/" + plugin, docRoot: docRoot });
-  logger.log("Add static contribution: " + sys.inspect(pluginsDocRoot));
+  util.log("Add static contribution: " + util.inspect(pluginsDocRoot));
 });
 
-logger.log('Server started.');
-logger.log('Server running at http://' + settings.hostname + ':' + settings.port);
+util.log('Server started.');
+util.log('Server running at http://' + settings.hostname + ':' + settings.port);
 

--- a/settings.js
+++ b/settings.js
@@ -1,5 +1,4 @@
 var os = require('os');
-var sys = require('sys');
 var fs = require('fs');
 var path = require("path");
 var logger = require('util');


### PR DESCRIPTION
Couple of changes

1) Upgraded redis version and added hiredis (basically deal with failures like FATAL ERROR: v8::HandleScope::Close() Local scope has already been closed)
2) used util instead of sys. (util was being mapped as logger, I left it as it is in most places, but used util where puts/inspect was being used). Feel free to modify it to your preference.

Other than this Journey needs to be replaced(or patched) to make the app work in node 0.6.x.
I posted a separate issue for that.
