### PR TITLE
Fix FS API change

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -3,6 +3,10 @@ var fs = require('fs');
 var path = require("path");
 var logger = require('util');
 
+// Hack nodejs API change
+fs.exists = fs.exists || require('path').exists;
+fs.existsSync = fs.existsSync || require('path').existsSync;
+
 exports.create = function() {
   var settings = {};
 


### PR DESCRIPTION
It is not possible to run statusdashboard on old node version with external appSettings. For example, on heroku fs.existsSync is not available. Current commit resolves this issue.
Tested on heroku and running at http://ow2statusboard.herokuapp.com
