### PR TITLE
Fix calls to EventEmitter

### DIFF
--- a/api.js
+++ b/api.js
@@ -98,7 +98,9 @@ module.exports.checkAllServices = function() {
     status.services[i].statusCode = 0;
     status.services[i].message = '';
 
-    sources[settings.services[i].check].call(null, settings.services[i], status.services[i], controller.emit);
+    sources[settings.services[i].check].call(null, settings.services[i], status.services[i], function(status, service) {
+      controller.emit(status, service);
+    });
   }
 
   /**


### PR DESCRIPTION
Wrong parameter was sent to checkers so the plugins were not receiving anything from the eventemitter.

-> Pass a callback and call emit inside. 
