### PR TITLE
Local Heartbeat

### DIFF
--- a/plugins/heartbeat/heartbeat_plugin.js
+++ b/plugins/heartbeat/heartbeat_plugin.js
@@ -1,0 +1,34 @@
+//
+// Periodically call the healtcheck HTTP URL.
+// This can be used on some Cloud providers to keep the app alive...
+//
+// For example, to keep the app alive on Heroku:
+//
+//  1. Deploy your app
+//  2. Get the Heroku URL of your app
+//  3. Set the environment variable 'heroku config:add HEARTBEAT_URL=http://yourapp.herokuapp.com'
+//  4. Restart the app 'heroku restart'
+//
+// @chamerling
+//
+
+var http = require('http')
+  , logger = require('util');
+
+exports.create = function(api, settings) {
+  if (settings.plugins && settings.plugins.heartbeat && settings.plugins.heartbeat.enable) {
+    logger.log('Creating the plugin: ' + __filename);
+    
+    var url = process.env.HEARTBEAT_URL || 'http://' + (settings.hostname + ':' + (settings.port || '80')) + '/healthCheck'; 
+    
+    setInterval(function() {
+      logger.log('[HEARTBEAT] ' + url);
+      
+      http.get(url, function(response) {
+        logger.log('Got response from heartbeat');
+      }).on('error', function(e) {
+        logger.log('[HEARTBEAT] Error:' + e);
+      })
+    }, settings.plugins.heartbeat.period || 60000);
+  }
+};

--- a/settings.js
+++ b/settings.js
@@ -152,6 +152,10 @@ exports.create = function() {
       webhook: {
         enable : false,
         url: 'http://localhost:8080/api/webhook/test'
+      },
+      heartbeat: {
+        enable: false,
+        period: 20000
       }
     }
   };


### PR DESCRIPTION
Provides local heartbeat as a plugin. This local heartbeat will keep the application alive on Cloud providers. For example, when running on heroku, the application will go down if there is no activity/session/...
