### PR TITLE
Updates socket.io to 0.9.16, fixing some conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "node": ">=0.6.1"
   },
   "dependencies": {
-    "socket.io": "0.9.10",
+    "socket.io": "0.9.16",
     "express": "2.5.11",
     "underscore": "1.4.0",
     "irc": "0.3.4",


### PR DESCRIPTION
Turns out socketio 0.9.10 was conflicting with express and then express
kept complaining about "Headers already being sent", upgrading to 0.9.16
fixes this.

This fixes issue #51 
